### PR TITLE
Add 500 error with stacktrace logging

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,0 +1,4 @@
+# Changelog
+
+## v0.2
+* Add support for error logging tagged with the request id. Errors now are bunched up as a single JSON message in addition to the standard output for easier parsing of errors and matching requests to the resulting error.

--- a/README.md
+++ b/README.md
@@ -26,7 +26,7 @@ If [available in Hex](https://hex.pm/docs/publish), the package can be installed
         end
   3. Replace `Plug.Logger` with `Plug.LoggerJSON` in your plug pipeline (endpoint.ex for phoenix apps)
 
-### Recommended Setup
+## Recommended Setup
   * Configure this application
     * Add to your `config/config.exs` or `config/env_name.exs` ONLY if you want to filter params or headers:
 
@@ -60,6 +60,20 @@ If [available in Hex](https://hex.pm/docs/publish), the package can be installed
               parsers: [:urlencoded, :multipart, :json],
               pass: ["*/*"],
               json_decoder: Poison
+
+## Error Logging
+  * In router.ex of your phoenix project or your plug pipeline
+    * Add `require Logger`
+    * Add `use Plug.ErrorHandler`
+    * Add the following two private functions:
+            
+            defp handle_errors(%Plug.Conn{status: 500} = conn, %{kind: kind, reason: reason, stack: stacktrace}) do
+              Plug.LoggerJSON.log_error(kind, reason, stacktrace)
+              send_resp(conn, 500, Poison.encode!(%{errors: %{detail: "Internal server error"}}))
+            end
+
+            defp handle_errors(_, _), do: nil 
+
 
 ## Contributing
 Before submitting your pull request, please run:

--- a/test/plug/logger_json_test.exs
+++ b/test/plug/logger_json_test.exs
@@ -202,4 +202,41 @@ defmodule Plug.LoggerJSONTest do
       assert map["fastly_duration"] == 0
     end
   end
+
+  describe "500 error" do
+    test "logs the error" do
+      stacktrace = [{MyPlug, :index, 2,
+        [file: 'web/controllers/reaction_controller.ex', line: 53]},
+       {MyPlug, :action, 2,
+        [file: 'web/controllers/reaction_controller.ex', line: 1]},
+       {MyPlug, :phoenix_controller_pipeline, 2,
+        [file: 'web/controllers/reaction_controller.ex', line: 1]},
+       {MyPlug, :instrument, 4,
+        [file: 'lib/reactions/endpoint.ex', line: 1]},
+       {MyPlug, :dispatch, 2, [file: 'lib/phoenix/router.ex', line: 261]},
+       {MyPlug, :do_call, 2, [file: 'web/router.ex', line: 1]},
+       {MyPlug, :call, 2, [file: 'lib/plug/error_handler.ex', line: 64]},
+       {MyPlug, :phoenix_pipeline, 1,
+        [file: 'lib/reactions/endpoint.ex', line: 1]},
+       {MyPlug, :call, 2, [file: 'lib/reactions/endpoint.ex', line: 1]},
+       {Plug.Adapters.Cowboy.Handler, :upgrade, 4,
+        [file: 'lib/plug/adapters/cowboy/handler.ex', line: 15]},
+       {:cowboy_protocol, :execute, 4, [file: 'src/cowboy_protocol.erl', line: 442]}]
+
+      {conn, _} = conn(:get, "/")
+                  |> call
+
+      {_, message} = get_log(fn -> Plug.LoggerJSON.log_error(:error, %RuntimeError{message: "ERROR"}, stacktrace) end)
+
+      message = String.replace(message, "\e[31m", "")
+      message = String.replace(message, "\e[22m", "")
+      message = String.replace(message, "\n\e[0m", "")
+      message = String.replace(message, "{\"requ", "{\"requ")
+      error_log = Poison.decode! message
+
+      assert error_log["log_type"] == "error"
+      assert error_log["message"] == "** (RuntimeError) ERROR\n    web/controllers/reaction_controller.ex:53: Plug.LoggerJSONTest.MyPlug.index/2\n    web/controllers/reaction_controller.ex:1: Plug.LoggerJSONTest.MyPlug.action/2\n    web/controllers/reaction_controller.ex:1: Plug.LoggerJSONTest.MyPlug.phoenix_controller_pipeline/2\n    lib/reactions/endpoint.ex:1: Plug.LoggerJSONTest.MyPlug.instrument/4\n    lib/phoenix/router.ex:261: Plug.LoggerJSONTest.MyPlug.dispatch/2\n    web/router.ex:1: Plug.LoggerJSONTest.MyPlug.do_call/2\n    lib/plug/error_handler.ex:64: Plug.LoggerJSONTest.MyPlug.call/2\n    lib/reactions/endpoint.ex:1: Plug.LoggerJSONTest.MyPlug.phoenix_pipeline/1\n    lib/reactions/endpoint.ex:1: Plug.LoggerJSONTest.MyPlug.call/2\n    lib/plug/adapters/cowboy/handler.ex:15: Plug.Adapters.Cowboy.Handler.upgrade/4\n    src/cowboy_protocol.erl:442: :cowboy_protocol.execute/4\n"
+      assert error_log["request_id"] ==  nil
+    end
+  end
 end


### PR DESCRIPTION
* Add log_error func that will log exception stacktraces in JSON
* Update README
* Create Changelog
* Fix dialyzer warning by explicitly defining that a log call failing
should not raise a match error.