### PR TITLE
Use :error level for log_error function

### DIFF
--- a/lib/plug/logger_json.ex
+++ b/lib/plug/logger_json.ex
@@ -82,7 +82,7 @@ defmodule Plug.LoggerJSON do
 
   @spec log_error(atom(), map(), list()) :: atom()
   def log_error(kind, reason, stacktrace) do
-    _ = Logger.log :info, fn ->
+    _ = Logger.log :error, fn ->
       %{
         "log_type"    => "error",
         "message"     => Exception.format(kind, reason, stacktrace),


### PR DESCRIPTION
The `log_error` function logs at info level, which seems counter-intuitive. This changes it to use the error level.