### PR TITLE
Allow extra_paths to be specified to log additional fields

### DIFF
--- a/lib/plug/logger_json.ex
+++ b/lib/plug/logger_json.ex
@@ -26,6 +26,27 @@ defmodule Plug.LoggerJSON do
   ## Options
   * `:log` - The log level at which this plug should log its request info.
   Default is `:info`.
+  * `:extra_paths` - Extra paths that should be logged to the request.
+  Default is `[]`. Please see "Extra Paths" section for more information.
+
+  ## Extra Paths
+
+  Additional data can be logged alongside the request by specifying them in
+  the following format to the `:extra_paths` key:
+
+        extra_paths: [
+          {"user_id", [:assigns, :user, :user_id]},
+          {"other_id", [:private, :private_resource, :id]},
+          {"should_not_appear", [:private, :does_not_exist]}
+        ]
+
+  In this example, the `:user_id` is retrieved from `conn.assigns.user.user_id`
+  and added to the log if it exists. If the path is not found then the
+  additional field is not logged. The first argument in the pair is the key
+  that will be logged, the second argument is the path relative to conn that
+  the value will be found. The first entry in the list must be `:assigns` or
+  `:private`. It is also a requirement that the value is serialiazable as JSON
+  by the Poison library, otherwise an error will be raised.
   )
 
   alias Plug.Conn
@@ -45,37 +66,42 @@ defmodule Plug.LoggerJSON do
   @type time :: {non_neg_integer(), non_neg_integer(), non_neg_integer()}
 
   @spec init(opts) :: opts
-  def init(opts) do
-    Keyword.get(opts, :log, :info)
-  end
+  def init(opts), do: opts
 
   @spec call(Plug.Conn.t(), opts) :: Plug.Conn.t()
-  def call(conn, level) do
+  def call(conn, level_or_opts) when is_atom(level_or_opts) do
+    call(conn, level: level_or_opts)
+  end
+  def call(conn, opts) do
+    level = Keyword.get(opts, :log, :info)
     start = :os.timestamp()
 
     Conn.register_before_send(conn, fn conn ->
-      :ok = log(conn, level, start)
+      :ok = log(conn, level, start, opts)
       conn
     end)
   end
 
-  @spec log(Plug.Conn.t(), atom(), time()) :: atom() | no_return()
-  def log(conn, :error, start), do: log(conn, :info, start)
-  def log(conn, :info, start) do
+  @spec log(Plug.Conn.t(), atom(), time(), opts) :: atom() | no_return()
+  def log(conn, level, start, opts \\ [])
+  def log(conn, :error, start, opts), do: log(conn, :info, start, opts)
+  def log(conn, :info, start, opts) do
     _ = Logger.log :info, fn ->
       conn
       |> basic_logging(start)
       |> Map.merge(phoenix_attributes(conn))
+      |> Map.merge(extra_attributes(conn, opts))
       |> Poison.encode!
     end
   end
-  def log(conn, :warn, start), do: log(conn, :debug, start)
-  def log(conn, :debug, start) do
+  def log(conn, :warn, start, opts), do: log(conn, :debug, start, opts)
+  def log(conn, :debug, start, opts) do
     _ = Logger.log :info, fn ->
       conn
       |> basic_logging(start)
       |> Map.merge(debug_logging(conn))
       |> Map.merge(phoenix_attributes(conn))
+      |> Map.merge(extra_attributes(conn, opts))
       |> Poison.encode!
     end
   end
@@ -108,6 +134,22 @@ defmodule Plug.LoggerJSON do
       "request_id"      => req_id,
       "status"          => conn.status
     }
+  end
+
+  defp extra_attributes(conn, opts) do
+    paths = Keyword.get(opts, :extra_paths, [])
+    Enum.reduce(paths, %{}, fn {key, path}, acc ->
+      {map, path} =
+        case path do
+          [:assigns | tail] -> {conn.assigns, tail}
+          [:private | tail] -> {conn.private, tail}
+          _ -> {%{}, []}
+        end
+      case get_in(map, path) do
+        nil -> acc
+        val -> Map.put(acc, key, val)
+      end
+    end)
   end
 
   @spec client_version(%{String.t() => String.t()}) :: String.t()


### PR DESCRIPTION
To maintain backwards compatibility, an atom is still permitted when
using call. This could be the case if someone is manually calling the
`call` function.

The `log` function is also public, so the `opts` default to `[]`. This
is also for backwards compatibility.

This is a use case I often have when logging, wishing to attach some information about the user to the request to make it easier to track a users journey through the system.