### PR TITLE
Fix deprecation warnings on Elixir 1.7

### DIFF
--- a/mix.exs
+++ b/mix.exs
@@ -15,7 +15,7 @@ defmodule PlugLoggerJson.Mixfile do
       homepage_url: "https://github.com/bleacherreport/plug_logger_json",
       name: "Plug Logger JSON",
       package: package(),
-      preferred_cli_env: ["coveralls": :test, "coveralls.detail": :test, "coveralls.post": :test, "coveralls.html": :test],
+      preferred_cli_env: [coveralls: :test, "coveralls.detail": :test, "coveralls.post": :test, "coveralls.html": :test],
       source_url: "https://github.com/bleacherreport/plug_logger_json",
       start_permanent: Mix.env == :prod,
       test_coverage: [tool: ExCoveralls],


### PR DESCRIPTION
Elixir 1.7 does not permit unecessary quotes in keyword list keys.

 > warning: found quoted keyword "coveralls" but the quotes are not
 > required. Note that keywords are always atoms, even when quoted,
 > and quotes should only be used to introduced keywords with foreign
 > characters in them mix.exs:18