### PR TITLE
Allow overriding max parameter length from the default of 500

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,8 @@
 
 ## Master
 
+## 0.7.0
+* Extra configuration that allows setting the maximum length to store for query params
 
 ## 0.6.0
 * Extra configration that allows control of logging debug fields.

--- a/README.md
+++ b/README.md
@@ -20,7 +20,7 @@ The support policy is to support the last 2 major versions of Erlang and the thr
 
    ```elixir
    def deps do
-     [{:plug_logger_json, "~> 0.6.0"}]
+     [{:plug_logger_json, "~> 0.7.0"}]
    end
    ```
    
@@ -48,6 +48,14 @@ config :plug_logger_json,
   filtered_keys: ["password", "authorization"],
   suppressed_keys: ["api_version", "log_type"]
 ```
+
+The request parameters are truncated to a max length of 500 characters by default. This can be overridden by setting the `param_max_length` option.
+
+```elixir
+config :plug_logger_json,
+  param_max_length: 5000
+```
+
 
 ### Configure the logger (console)
   

--- a/lib/plug/logger_json.ex
+++ b/lib/plug/logger_json.ex
@@ -203,7 +203,8 @@ defmodule Plug.LoggerJSON do
   end
 
   defp format_value(value) when is_binary(value) do
-    String.slice(value, 0..500)
+    max = Application.get_env(:plug_logger_json, :param_max_length, 500)
+    String.slice(value, 0..max)
   end
 
   defp format_value(value) do

--- a/mix.exs
+++ b/mix.exs
@@ -19,7 +19,7 @@ defmodule PlugLoggerJson.Mixfile do
       source_url: "https://github.com/bleacherreport/plug_logger_json",
       start_permanent: Mix.env == :prod,
       test_coverage: [tool: ExCoveralls],
-      version: "0.6.0",
+      version: "0.7.0",
     ]
   end
 


### PR DESCRIPTION
This allows overriding the maximum length of parameters that are logged from the default of 500.