### PR TITLE
Improve filtering of structs

### DIFF
--- a/lib/plug/logger_json.ex
+++ b/lib/plug/logger_json.ex
@@ -184,8 +184,10 @@ defmodule Plug.LoggerJSON do
   end
 
   @spec filter_values(struct(), [binary()]) :: binary()
-  defp filter_values(%{__struct__: mod} = struct, _) when is_atom(mod) do
-    inspect(struct)
+  defp filter_values(%{__struct__: mod} = struct, filters) when is_atom(mod) do
+    struct
+    |> Map.from_struct()
+    |> filter_values(filters)
   end
 
   @spec filter_values(map(), [binary()]) :: [{binary(), any()}]

--- a/test/plug/logger_json_test.exs
+++ b/test/plug/logger_json_test.exs
@@ -334,7 +334,7 @@ defmodule Plug.LoggerJSONTest do
       |> Poison.decode!()
       |> get_in(["params"])
 
-    assert params["photo"] == "%Plug.Upload{content_type: nil, filename: nil, path: nil}"
+    assert params["photo"] == %{"content_type" => nil, "filename" => nil, "path" => nil}
   end
 
   describe "500 error" do


### PR DESCRIPTION
This PR improves on the filtering of struct values. Instead of
inspecting the struct (which could expose keys that should be filtered)
this PR turns the struct into a map and then applies filtering to this
map.